### PR TITLE
Ouistiti - Add a button to randomise player order while in the lobby screen

### DIFF
--- a/libs/ouistiti-ui/src/lib/components/game-flow/end-of-game-container/end-of-game-container.component.ts
+++ b/libs/ouistiti-ui/src/lib/components/game-flow/end-of-game-container/end-of-game-container.component.ts
@@ -31,7 +31,7 @@ export class EndOfGameContainerComponent {
       reversedScores.find(
         (roundScore: RoundScores) =>
           typeof roundScore?.playerScores[0]?.pointDifference === 'number'
-      ).roundNumber ?? 1
+      )?.roundNumber ?? 1
     );
   }
 

--- a/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.html
+++ b/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.html
@@ -1,7 +1,7 @@
 <div class="section">
-  <div class="inner-section">
+  <div class="inner-section" [class.randomising-player-order]="isPlayerOrderRandomising">
     <tmk-ouistiti-player-list
-      [players]="playerList$ | async"
+      [players]="playersInList(playerList$ | async)"
       [hostId]="hostId$ | async"
       [selfId]="selfId"
       [maxNumberOfPlayers]="maxNumberOfPlayers$ | async"
@@ -61,6 +61,13 @@
           (click)="startGame()"
         >
           <fa-icon [icon]="faPlay"></fa-icon>Start game
+        </button>
+        <button
+          class="button-colour-blue"
+          [disabled]="!canRandomisePlayerOrder(playerList$ | async)"
+          (click)="randomisePlayerOrder()"
+        >
+          <fa-icon [icon]="faRandom"></fa-icon>Randomise players
         </button>
       </div>
     </div>

--- a/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.scss
+++ b/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.scss
@@ -25,6 +25,10 @@
       .buttons-row {
         margin-top: 20px;
       }
+
+      &.randomising-player-order tmk-ouistiti-player-list {
+        pointer-events: none;
+      }
     }
   }
 }

--- a/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.ts
+++ b/libs/ouistiti-ui/src/lib/components/lobby-screen/lobby-screen.component.ts
@@ -12,14 +12,8 @@ import {
 } from '@TomikaArome/ouistiti-shared';
 import { PlayerService } from '../../services/player.service';
 import { LobbyService } from '../../services/lobby.service';
-import {
-  faBan,
-  faCrown,
-  faDoorOpen,
-  faPlay,
-} from '@fortawesome/free-solid-svg-icons';
+import { faBan, faCrown, faDoorOpen, faPlay, faRandom } from '@fortawesome/free-solid-svg-icons';
 import { Subject } from 'rxjs';
-import { RoundService } from '../../services/round.service';
 
 @Component({
   selector: 'tmk-ouistiti-lobby-screen',
@@ -68,12 +62,16 @@ export class LobbyScreenComponent implements OnDestroy {
   faBan = faBan;
   faDoorOpen = faDoorOpen;
   faPlay = faPlay;
+  faRandom = faRandom;
+
+  get isPlayerOrderRandomising(): boolean {
+    return this.lobbyService.isPlayerOrderRandomising;
+  }
 
   constructor(
     private socketService: SocketService,
     private playerService: PlayerService,
-    private lobbyService: LobbyService,
-    private roundService: RoundService
+    private lobbyService: LobbyService
   ) {
     this.playerService.isHost$
       .pipe(takeUntil(this.onDestroy$))
@@ -155,11 +153,25 @@ export class LobbyScreenComponent implements OnDestroy {
     this.lobbyService.startGame();
   }
 
+  randomisePlayerOrder() {
+    this.lobbyService.randomisePlayerOrder();
+  }
+
   canStartGame(playerList: PlayerInfo[]): boolean {
     return (
       playerList.length >= MIN_NUMBER_OF_PLAYERS_PER_LOBBY &&
       playerList.length <= MAX_NUMBER_OF_PLAYERS_PER_LOBBY
     );
+  }
+
+  canRandomisePlayerOrder(playerList: PlayerInfo[]): boolean {
+    return playerList.length > 2 && !this.lobbyService.isPlayerOrderRandomising;
+  }
+
+  playersInList(actualPlayerOrder: PlayerInfo[]): PlayerInfo[] {
+    return this.isPlayerOrderRandomising ? this.lobbyService.fakePlayerOrderWhileRandomising.map((playerId: string) => {
+      return actualPlayerOrder.find((player: PlayerInfo) => player.id === playerId);
+    }) : actualPlayerOrder;
   }
 
   ngOnDestroy() {

--- a/libs/ouistiti-ui/src/lib/components/player-list/player-list.component.ts
+++ b/libs/ouistiti-ui/src/lib/components/player-list/player-list.component.ts
@@ -61,9 +61,7 @@ export class PlayerListComponent {
     return this.expandedPlayerId === player.id;
   }
   setExpandedPlayer(player: PlayerInfo, isExpanded: boolean) {
-    if (isExpanded) {
-      this.expandedPlayerId = player.id;
-    }
+    this.expandedPlayerId = isExpanded ? player.id : null;
   }
 
   sortableListOrderChanged(order: PlayerInfo[]) {

--- a/libs/ouistiti-ui/src/lib/services/socket.service.ts
+++ b/libs/ouistiti-ui/src/lib/services/socket.service.ts
@@ -16,7 +16,7 @@ import {
   roundStatusMock,
   lobbyStatusPlayerIsHostMock,
   lobbyListMock,
-  getGameScoresMock,
+  getGameScoresMock
 } from '@TomikaArome/ouistiti-shared';
 import { ServerEvent } from '../classes/server-event.class';
 
@@ -64,6 +64,7 @@ export class SocketService {
     new ServerEvent<LobbyInfo[]>('lobbyList', this.lobbyListInitialValue),
     new ServerEvent<LobbyInfo>('lobbyUpdated'),
     new ServerEvent<LobbyClosed>('lobbyClosed'),
+    new ServerEvent<LobbyInfo>('playerOrderRandomised'),
 
     new ServerEvent<RoundScores[]>('scores', this.gameScoresInitialValue),
 

--- a/libs/ouistiti/src/lib/controllers/socket-lobby.controller.ts
+++ b/libs/ouistiti/src/lib/controllers/socket-lobby.controller.ts
@@ -1,16 +1,9 @@
 import { SocketController } from './socket.controller';
 import { Lobby } from '../classes/lobby.class';
 import { debounceTime, filter, map, takeUntil, tap } from 'rxjs/operators';
-import {
-  LobbyJoinObserved,
-  LobbyLeftObserved,
-} from '../interfaces/lobby-oberserved.interface';
+import { LobbyJoinObserved, LobbyLeftObserved, } from '../interfaces/lobby-oberserved.interface';
 import { merge, MonoTypeOperatorFunction, Observable } from 'rxjs';
-import {
-  GameStatus,
-  LobbyClosed,
-  LobbyStatus,
-} from '@TomikaArome/ouistiti-shared';
+import { GameStatus, LobbyClosed, LobbyStatus } from '@TomikaArome/ouistiti-shared';
 import { SocketPlayerController } from './socket-player.controller';
 import { SocketGameController } from './socket-game.controller';
 import { Game } from '../classes/game.class';
@@ -45,6 +38,7 @@ export class SocketLobbyController {
     this.subscribeLobbyClosed();
     this.subscribeGameStarted();
     this.subscribeGameEnded();
+    this.subscribePlayerOrderRandomised();
 
     this.init();
   }
@@ -116,7 +110,8 @@ export class SocketLobbyController {
       this.lobby.hostChanged$,
       this.lobby.playerOrderChanged$,
       this.lobby.maximumNumberOfPlayersChanged$,
-      this.lobby.vacancyFilled$
+      this.lobby.vacancyFilled$,
+      this.lobby.playerOrderRandomised$
     )
       .pipe(this.stop, debounceTime(SocketController.debounceTime))
       .subscribe(() => {
@@ -156,6 +151,12 @@ export class SocketLobbyController {
   subscribeGameEnded() {
     this.lobby.gameEnded$.pipe(this.stop).subscribe(() => {
       this.emitLobbyStatus();
+    });
+  }
+
+  subscribePlayerOrderRandomised() {
+    this.lobby.playerOrderRandomised$.pipe(this.stop).subscribe(() => {
+      this.controller.emit('playerOrderRandomised', this.lobby.info);
     });
   }
 }

--- a/libs/ouistiti/src/lib/ouistiti.gateway.ts
+++ b/libs/ouistiti/src/lib/ouistiti.gateway.ts
@@ -124,6 +124,15 @@ export class OuistitiGateway {
     }
   }
 
+  @UseFilters(new OuistitiExceptionFilter('randomisePlayerOrder'))
+  @SubscribeMessage('randomisePlayerOrder')
+  randomisePlayerOrder(socket: Socket) {
+    OuistitiException.checkIfInLobby(socket.data.controller);
+    OuistitiException.checkIfHost(socket.data.controller);
+
+    socket.data.controller.player.lobby.changeOrder();
+  }
+
   @UseFilters(new OuistitiExceptionFilter('kickPlayer'))
   @SubscribeMessage('kickPlayer')
   kickPlayer(socket: Socket, params: PlayerKickParams) {


### PR DESCRIPTION
When creating a lobby, the host will see a new button next to "Start game" to randomise the order of the players in the lobby. This will play a one second animation for all connected players in which the player names will rapidly get shuffled around before settling on a final order.

This will save having to randomise the player order randomly outside of the game and manually setting it to that order.

This PR also fixes two small bugs:
- Fixed an error message appearing in console when you pause the game during the first round when there haven't yet been any scores registered, as the code is expecting there to be an array with at least one element.
- Fixed a bug where reordering the players after expanding and then collapsing the edit player info in the lobby screen as host will automatically expand it again.