### PR TITLE
Fix not handling case where playing with more than 6 players in Ouistiti results in more than 52 cards

### DIFF
--- a/libs/ouistiti/src/lib/classes/game.class.ts
+++ b/libs/ouistiti/src/lib/classes/game.class.ts
@@ -59,6 +59,7 @@ export class Game {
     const newGame = new Game();
     newGame.playerOrder = settings.playerOrder;
     newGame.maxCardsPerPlayer = settings.maxCardsPerPlayer;
+    if (newGame.playerOrder.length > 6) { newGame.maxCardsPerPlayer = 6; }
     newGame.newRound();
     return newGame;
   }

--- a/libs/ouistiti/src/lib/classes/round.class.ts
+++ b/libs/ouistiti/src/lib/classes/round.class.ts
@@ -123,6 +123,10 @@ export class Round {
     this.playerIds = settings.playerIds;
     this.maxCardsPerPlayer = settings.maxCardsPerPlayer;
     this.numberOfCardsPerPlayer = settings.numberOfCardsPerPlayer;
+    if (this.playerIds.length > 6) {
+      this.maxCardsPerPlayer = 6;
+      this.numberOfCardsPerPlayer = 6;
+    }
     this.currentPlayerId = this.startingPlayerId;
   }
 


### PR DESCRIPTION
If playing with 7 or 8 players in Ouistiti, the maximum number of cards you can get in one hand is now capped at 6. This means that, for 7 players, there would be a total of 42 cards (with the lowest cards being the 4 of spades and hearts), and for 8 players, there would be a total of 48 cards (with the lowest cards being 3s).

Obviously, the case for 7 players can be especially confusing, as only two of the 4s are out. TODO: show somewhere in the UI what cards are available in the deck.